### PR TITLE
update data-table to persist sort order into localStorage

### DIFF
--- a/src/components/data-table/index.js
+++ b/src/components/data-table/index.js
@@ -1,12 +1,18 @@
+import { useEffect } from 'react';
 import { useTable, useSortBy, useExpanded, usePagination } from 'react-table';
 // import {ReactComponent as ArrowIcon} from './Arrow.js';
 import ArrowIcon from './Arrow.js';
+import useStateWithLocalStorage from '../../hooks/useStateWithLocalStorage';
 
 import './index.css';
 
 function DataTable({ columns, data, sortBy, sortByDesc, autoResetSortBy, className, maxItems, extraRow }) {
     // Use the state and functions returned from useTable to build your UI
     // const [data, setData] = React.useState([])
+    
+    const storageKey = columns.map(({ Header }) => Header).join(',');
+    const [ initialSortBy, setSortBy ] = useStateWithLocalStorage(storageKey, [{id: sortBy, desc: sortByDesc}]);
+
     const {
         getTableProps,
         getTableBodyProps,
@@ -14,20 +20,20 @@ function DataTable({ columns, data, sortBy, sortByDesc, autoResetSortBy, classNa
         page,
         rows,
         prepareRow,
+        state: { sortBy: sortByState } = {},
     } = useTable({
         columns,
         data,
         initialState: {
             pageSize: maxItems,
-            sortBy: [
-                {
-                    id: sortBy,
-                    desc: sortByDesc,
-                },
-            ],
+            sortBy: initialSortBy,
         },
         autoResetSortBy: autoResetSortBy,
     }, useSortBy, useExpanded, usePagination);
+
+    useEffect(() => {
+        setSortBy(sortByState)
+    });
 
     const getRows = () => {
         let rowContainer = rows;


### PR DESCRIPTION
Meant to address #95 for Hacktoberfest - this uses `useStateWithLocalStorage` within `data-table/index.js` to store and retrieve the sort order for a table to local storage.

I'm not 100% happy with the implementation here, as I'd like to use something better for `storageKey` - I see that barters-table for example has a key attribute on `<DataTable>` but I'm probably too new to react (I mostly use Vue) to understand why I can't seem to retrieve that value to use for the `storageKey`. I'll happily make some tweaks if you've got suggestions.

Happy Hacktoberfest!