### PR TITLE
Add Java's builtin HttpClient example in API docs

### DIFF
--- a/src/pages/api-docs/index.js
+++ b/src/pages/api-docs/index.js
@@ -192,6 +192,52 @@ $data = @file_get_contents('https://tarkov-tools.com/graphql', false, stream_con
 return json_decode($data, true);`}
             </SyntaxHighlighter>
         </div>
+        <div
+            className = 'example-wrapper'
+        >
+            <h3>
+                Java 11's HttpClient {t('example')}
+            </h3>
+            <SyntaxHighlighter
+                language = 'java'
+                style = {atomOneDark}
+            >
+                {`import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+class Scratch {
+    public static void main(String[] args) throws IOException, InterruptedException {
+        ObjectMapper om = new ObjectMapper();
+        HttpClient client = HttpClient.newBuilder().build();
+        String query = """
+                    {
+                      itemsByName(name: "m855a1") {
+                        id
+                        name
+                        shortName
+                      }
+                    }""";
+        String jsonQuery = om.writeValueAsString(Map.of("query", query)); // properly escapes
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://tarkov-tools.com/graphql"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonQuery))
+                .build();
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        String jsonString = response.body();
+        System.out.println(jsonString);
+    }
+}
+`}
+            </SyntaxHighlighter>
+        </div>
     </div>;
 };
 


### PR DESCRIPTION
<details>
	<summary>Working code example.</summary>

![idea64_5lzEaN0ro3](https://user-images.githubusercontent.com/7574664/150445436-8714c8d3-f230-4adc-a47f-2d5a961ff6cc.png)
</details>
Firefox does throw this error in the JS console which is odd, not sure what I changed:

![firefox_ah4KguN22j](https://user-images.githubusercontent.com/7574664/150445781-63801400-8099-4aec-8d96-c4f68f5a9f42.png)

