### PR TITLE
Make it possible to hide remote control id box

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,12 +84,6 @@ cite {
 	font-size: 14px;
 }
 
-.update-label {
-	font-size: 10px;
-	text-align: center;
-	color: #ccc;
-}
-
 .display-wrapper {
 	height: var(--display-height);
     min-height: 80vh;
@@ -143,98 +137,6 @@ cite {
 	object-fit: contain;
 }
 
-.id-wrapper {
-	background-color: rgba(0, 0, 0, 0.5);
-	bottom: 0;
-	color: #fff;
-	display: none;
-	font-family: bender;
-	font-size: 30px;
-	line-height: 20px;
-	padding: 10px 40px;
-	position: fixed;
-}
-
-.id-wrapper-left {
-	left: 0;
-}
-.id-wrapper-right {
-	right: 0;
-}
-
-.session-question {
-	/* background-color: black; */
-	border-radius: 50%;
-	font-size: 16px;
-	font-weight: bold;
-	height: 30px;
-	line-height: 30px;
-	position: absolute;
-	right: 0px;
-	text-align: center;
-	top: 0px;
-	width: 30px;
-}
-
-.session-question:hover .session-popup {
-	display: block;
-}
-
-.session-popup {
-	display: none;
-	position: absolute;
-	bottom: 0;
-	width: 30vw;
-	background-color: rgba(0, 0, 0, 0.8);
-	padding: 15px;
-	font-size: 16px;
-}
-
-.id-wrapper-left .session-popup {
-	left: 0;
-}
-
-.id-wrapper-right .session-popup {
-	right: 0;
-}
-
-.session-switch-side {
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	font-size: 16px;
-	font-weight: bold;
-	height: 30px;
-	width: 30px;
-	line-height: 30px;
-	text-align: center;
-	background-color: transparent;
-	border: none;
-	cursor: pointer;
-	text-decoration: none;
-	color: #ccc;
-}
-
-.session-switch-side:hover,
-.session-switch-side:focus,
-.session-switch-side:active {
-	text-decoration: none;
-}
-
-.id-wrapper svg {
-	fill: #c7c5b3;
-	height: 35px;
-	margin-right: 1vh;
-	width: 35px;
-}
-
-.session-id {
-	display: inline-block;
-	line-height: 23px;
-	position: relative;
-	top: -6px;
-}
-
 .icon-with-text {
 	vertical-align: middle;
 	margin-right: 8px;
@@ -274,10 +176,6 @@ div.tippy-box {
 }
 
 @media screen and (min-width: 710px) {
-	.id-wrapper {
-		display: block;
-	}
-
 	.control-wrapper {
 		display: none;
 	}

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ import './i18n';
 import loadPolyfills from './modules/polyfills';
 
 import Map from './components/Map.jsx';
-import ID from './components/ID.jsx';
+import ID from './components/remote-control-id';
 import Menu from './components/menu';
 import Footer from './components/footer';
 

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ import './i18n';
 import loadPolyfills from './modules/polyfills';
 
 import Map from './components/Map.jsx';
-import ID from './components/remote-control-id';
+import RemoteControlId from './components/remote-control-id';
 import Menu from './components/menu';
 import Footer from './components/footer';
 
@@ -204,6 +204,13 @@ function App() {
         }));
     }, [controlId]);
 
+    const remoteControlSessionElement = <RemoteControlId
+        key = 'connection-wrapper'
+        sessionID = {sessionID}
+        socketEnabled = {socketEnabled}
+        onClick = {e => dispatch(enableConnection())}
+        />;
+
 return (
     <div
         className = 'App'
@@ -227,12 +234,7 @@ return (
                     <Start
                         key = 'start-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />]
+                    remoteControlSessionElement]
                 }
             />
             <Route
@@ -241,12 +243,7 @@ return (
                     <Start
                         key = 'start-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />]
+                    remoteControlSessionElement]
                 }
             />
             <Route
@@ -268,12 +265,7 @@ return (
                         </Helmet>
                         <Ammo />
                     </div>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -295,12 +287,7 @@ return (
                         </Helmet>
                         <Ammo />
                     </div>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -309,12 +296,7 @@ return (
                     <Maps
                         key = 'maps-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -326,12 +308,7 @@ return (
                     >
                         <Map />
                     </div>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -341,12 +318,7 @@ return (
                         sessionID = {sessionID}
                         key = 'loot-tier-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -356,11 +328,7 @@ return (
                         sessionID = {sessionID}
                         key = 'loot-tier-wrapper'
                     />,
-                    <ID
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement,
                 ]}
             />
             <Route
@@ -370,12 +338,7 @@ return (
                         sessionID = {sessionID}
                         key = 'loot-tier-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -384,12 +347,7 @@ return (
                     <Barters
                         key = 'barters-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -398,12 +356,7 @@ return (
                     <Items
                         key = 'items-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -413,12 +366,7 @@ return (
                         sessionID = {sessionID}
                         key = 'helmets-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
 
@@ -429,12 +377,7 @@ return (
                         sessionID = {sessionID}
                         key = 'glasses-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -444,12 +387,7 @@ return (
                         sessionID = {sessionID}
                         key = 'armor-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -459,12 +397,7 @@ return (
                         sessionID = {sessionID}
                         key = 'backpacks-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -474,12 +407,7 @@ return (
                         sessionID = {sessionID}
                         key = 'rigs-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -489,12 +417,7 @@ return (
                         sessionID = {sessionID}
                         key = 'suppressors-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -504,12 +427,7 @@ return (
                         sessionID = {sessionID}
                         key = 'guns-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -519,12 +437,7 @@ return (
                         sessionID = {sessionID}
                         key = 'mods-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -534,12 +447,7 @@ return (
                         sessionID = {sessionID}
                         key = 'pistol-grips-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -549,12 +457,7 @@ return (
                         sessionID = {sessionID}
                         key = 'barter-items-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -564,12 +467,7 @@ return (
                         sessionID = {sessionID}
                         key = 'containers-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -579,12 +477,7 @@ return (
                         sessionID = {sessionID}
                         key = 'grenades-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -594,12 +487,7 @@ return (
                         sessionID = {sessionID}
                         key = 'headsets-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -609,12 +497,7 @@ return (
                         sessionID = {sessionID}
                         key = 'keys-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -624,12 +507,7 @@ return (
                         sessionID = {sessionID}
                         key = 'provisions-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -639,12 +517,7 @@ return (
                         sessionID = {sessionID}
                         key = 'traders-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -654,12 +527,7 @@ return (
                         sessionID = {sessionID}
                         key = 'prapor-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -669,12 +537,7 @@ return (
                         sessionID = {sessionID}
                         key = 'therapist-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -684,12 +547,7 @@ return (
                         sessionID = {sessionID}
                         key = 'skier-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -699,12 +557,7 @@ return (
                         sessionID = {sessionID}
                         key = 'peacekeeper-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -714,12 +567,7 @@ return (
                         sessionID = {sessionID}
                         key = 'mechanic-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -729,12 +577,7 @@ return (
                         sessionID = {sessionID}
                         key = 'ragman-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -744,12 +587,7 @@ return (
                         sessionID = {sessionID}
                         key = 'jaeger-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -758,12 +596,7 @@ return (
                     <Crafts
                         key = 'hideout-profit-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -772,12 +605,7 @@ return (
                     <ItemTracker
                         key = 'item-tracker-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -787,12 +615,7 @@ return (
                         sessionID = {sessionID}
                         key = 'specific-item-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -801,12 +624,7 @@ return (
                     <Debug
                         key = 'debug-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -815,12 +633,7 @@ return (
                     <About
                         key = 'about-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -832,12 +645,7 @@ return (
                     >
                         <APIDocs />
                     </Suspense>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -849,12 +657,7 @@ return (
                     >
                         <Nightbot />
                     </Suspense>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -866,12 +669,7 @@ return (
                     >
                         <StreamElements />
                     </Suspense>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -883,12 +681,7 @@ return (
                     >
                         <Moobot />
                     </Suspense>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -900,12 +693,7 @@ return (
                     >
                         <ApiUsers />
                     </Suspense>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -917,12 +705,7 @@ return (
                     >
                         <HistoryGraphs />
                     </Suspense>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -931,12 +714,7 @@ return (
                     <Hideout
                         key = 'hideout-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -945,12 +723,7 @@ return (
                     <WipeLength
                         key = 'wipe-length-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -959,12 +732,7 @@ return (
                     <Settings
                         key = 'settings-wrapper'
                     />,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             <Route
@@ -992,12 +760,7 @@ return (
                     >
                         <BsgCategory />
                     </div>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             />
             {/* <Route
@@ -1009,17 +772,12 @@ return (
                     >
                         <GunBuilder />
                     </div>,
-                    <ID
-                        key = 'connection-wrapper'
-                        sessionID = {sessionID}
-                        socketEnabled = {socketEnabled}
-                        onClick = {e => dispatch(enableConnection())}
-                    />
+                    remoteControlSessionElement
                 ]}
             /> */}
             <Route
                 path="*"
-                element={<ErrorPage />}
+                element={[<ErrorPage />, remoteControlSessionElement]}
             />
         </Routes>
     {/* </Suspense> */}

--- a/src/App.js
+++ b/src/App.js
@@ -204,7 +204,8 @@ function App() {
         }));
     }, [controlId]);
 
-    const remoteControlSessionElement = <RemoteControlId
+    const hideRemoteControlId = useSelector((state) => state.settings.hideRemoteControl);
+    const remoteControlSessionElement = hideRemoteControlId ? null : <RemoteControlId
         key = 'connection-wrapper'
         sessionID = {sessionID}
         socketEnabled = {socketEnabled}

--- a/src/components/error-page/index.js
+++ b/src/components/error-page/index.js
@@ -1,7 +1,7 @@
 import {Helmet} from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
-import ID from '../ID.jsx';
+import ID from '../remote-control-id';
 import ItemSearch from '../item-search/index.js';
 
 import './index.css';

--- a/src/components/error-page/index.js
+++ b/src/components/error-page/index.js
@@ -1,7 +1,6 @@
 import {Helmet} from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 
-import ID from '../remote-control-id';
 import ItemSearch from '../item-search/index.js';
 
 import './index.css';
@@ -31,11 +30,7 @@ function ErrorPage(props) {
             <ItemSearch
                 showDropdown
             />
-        </div>,
-        <ID
-            key = {'session-id'}
-            sessionID = {props.sessionID}
-        />
+        </div>
     ];
 };
 

--- a/src/components/loading/index.js
+++ b/src/components/loading/index.js
@@ -1,6 +1,6 @@
 import {Bars} from 'react-loader-spinner';
 
-import ID from '../ID.jsx';
+import ID from '../remote-control-id';
 
 import './index.css';
 

--- a/src/components/loading/index.js
+++ b/src/components/loading/index.js
@@ -1,11 +1,9 @@
 import {Bars} from 'react-loader-spinner';
 
-import ID from '../remote-control-id';
-
 import './index.css';
 
 function Loading(props) {
-    return [
+    return (
         <div
             className="display-wrapper"
             key = {'display-wrapper'}
@@ -21,12 +19,8 @@ function Loading(props) {
                     width={100}
                 />
             </div>
-        </div>,
-        <ID
-            key = {'session-id'}
-            sessionID = {props.sessionID}
-        />
-    ];
+        </div>
+    );
 };
 
 export default Loading;

--- a/src/components/remote-control-id/index.css
+++ b/src/components/remote-control-id/index.css
@@ -1,0 +1,103 @@
+.id-wrapper {
+  background-color: rgba(0, 0, 0, 0.5);
+  bottom: 0;
+  color: #fff;
+  display: none;
+  font-family: bender;
+  font-size: 30px;
+  line-height: 20px;
+  padding: 10px 40px;
+  position: fixed;
+}
+
+.id-wrapper-left {
+  left: 0;
+}
+.id-wrapper-right {
+  right: 0;
+}
+
+.session-question {
+  /* background-color: black; */
+  border-radius: 50%;
+  font-size: 16px;
+  font-weight: bold;
+  height: 30px;
+  line-height: 30px;
+  position: absolute;
+  right: 0px;
+  text-align: center;
+  top: 0px;
+  width: 30px;
+}
+
+.session-question:hover .session-popup {
+  display: block;
+}
+
+.session-popup {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  width: 30vw;
+  background-color: rgba(0, 0, 0, 0.8);
+  padding: 15px;
+  font-size: 16px;
+}
+
+.id-wrapper-left .session-popup {
+  left: 0;
+}
+
+.id-wrapper-right .session-popup {
+  right: 0;
+}
+
+.session-switch-side {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  font-size: 16px;
+  font-weight: bold;
+  height: 30px;
+  width: 30px;
+  line-height: 30px;
+  text-align: center;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  color: #ccc;
+}
+
+.session-switch-side:hover,
+.session-switch-side:focus,
+.session-switch-side:active {
+  text-decoration: none;
+}
+
+.id-wrapper svg {
+  fill: #c7c5b3;
+  height: 35px;
+  margin-right: 1vh;
+  width: 35px;
+}
+
+.session-id {
+  display: inline-block;
+  line-height: 23px;
+  position: relative;
+  top: -6px;
+}
+
+.update-label {
+	font-size: 10px;
+	text-align: center;
+	color: #ccc;
+}
+
+@media screen and (min-width: 710px) {
+  .id-wrapper {
+    display: block;
+  }
+}

--- a/src/components/remote-control-id/index.jsx
+++ b/src/components/remote-control-id/index.jsx
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import './index.css';
+
 const Sides = {
     Left: 'Left',
     Right: 'Right',

--- a/src/components/remote-control-id/index.jsx
+++ b/src/components/remote-control-id/index.jsx
@@ -1,6 +1,5 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSelector } from 'react-redux';
 
 import './index.css';
 
@@ -12,8 +11,6 @@ const Sides = {
 function ID(props) {
     const [side, setSide] = useState(Sides.Left);
     const {t} = useTranslation();
-
-    const hide = useSelector((state) => state.settings.hideRemoteControl);
 
     let sideClass;
     let sideButtonContent;
@@ -31,10 +28,6 @@ function ID(props) {
     const handleSwitchSideClick = useCallback(() => {
         setSide(otherSide)
     }, [setSide, otherSide]);
-
-    if (hide) {
-        return null;
-    }
 
     return <div
         className={`id-wrapper ${ sideClass }`}

--- a/src/components/remote-control-id/index.jsx
+++ b/src/components/remote-control-id/index.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
 
 import './index.css';
 
@@ -11,6 +12,8 @@ const Sides = {
 function ID(props) {
     const [side, setSide] = useState(Sides.Left);
     const {t} = useTranslation();
+
+    const hide = useSelector((state) => state.settings.hideRemoteControl);
 
     let sideClass;
     let sideButtonContent;
@@ -28,6 +31,10 @@ function ID(props) {
     const handleSwitchSideClick = useCallback(() => {
         setSide(otherSide)
     }, [setSide, otherSide]);
+
+    if (hide) {
+        return null;
+    }
 
     return <div
         className={`id-wrapper ${ sideClass }`}

--- a/src/features/settings/settingsSlice.js
+++ b/src/features/settings/settingsSlice.js
@@ -114,6 +114,7 @@ const settingsSlice = createSlice({
         completedQuests: [],
         useTarkovTracker: JSON.parse(localStorage.getItem('useTarkovTracker')) || false,
         tarkovTrackerModules: [],
+        'hideRemoteControl': JSON.parse(localStorage.getItem('hide-remote-control')) || false,
     },
     reducers: {
         setTarkovTrackerAPIKey: (state, action) => {


### PR DESCRIPTION
Currently it can only be hidden by setting the local storage key `hide-remote-control` to `true` but I wasn't really sure where to put it. A cross on the element would be too easy to click by misstake so maybe just a toggle on the settings page? But it didn't really fit anywhere.

But I would just be happy to be able to hide it for me because it's in the way when looking at ammo charts or maps.